### PR TITLE
More docs, default timeouts, definitions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 mqrpc.sublime-workspace
 dist
+.envrc

--- a/lib/RpcClient.ts
+++ b/lib/RpcClient.ts
@@ -32,8 +32,8 @@ export default class RpcClient {
   amqpClient: AmqpClient
   rpcExchangeName = 'mqrpc'
   ackTimeout = 0
-  idleTimeout = 60000 // 1 minute
-  callTimeout = 0
+  idleTimeout = 0
+  callTimeout = 900000 // 15 minutes
   log = logger as StandardLogger
 
   /**
@@ -47,8 +47,8 @@ export default class RpcClient {
    * @param {RpcOptions}        [opts.rpcClient]                 Config for the client itself.
    * @param {string}            [opts.rpcClient.rpcExchangeName] Exchange where calls are published. Default 'mqrpc'. Must match server.
    * @param {number}            [opts.rpcClient.ackTimeout]      In ms, how long to wait for a server's ack. Default infinite (0).
-   * @param {number}            [opts.rpcClient.idleTimeout]     In ms, how long can a server be unresponsive. Default 1min.
-   * @param {number}            [opts.rpcClient.callTimeout]     In ms, how long overall to wait for a call's return.
+   * @param {number}            [opts.rpcClient.idleTimeout]     In ms, how long can a server be unresponsive. Default infinite (0).
+   * @param {number}            [opts.rpcClient.callTimeout]     In ms, how long overall to wait for a call's return. Default 15 minutes.
    * @param {StandardLogger}    [opts.rpcClient.logger]          Custom logger for client use.
    */
   constructor(opts: RpcClientOptions) {

--- a/lib/Timer.ts
+++ b/lib/Timer.ts
@@ -11,11 +11,11 @@ export interface Timeout {
   length: number
 }
 
-interface ActiveTimeout extends Timeout {
+export interface ActiveTimeout extends Timeout {
   handle: NodeJS.Timer
 }
 
-interface Entry {
+export interface Entry {
   readonly promise: Promise<any>
   readonly reject: Function
   readonly timeouts: Map<string, ActiveTimeout>

--- a/test/RpcClient/call.ts
+++ b/test/RpcClient/call.ts
@@ -34,7 +34,7 @@ test('[unit] #call publishes the procedure call', async t => {
 
   await delay(1) // let the publish happen
 
-  const timeouts = { idleTimeout: 60000, callTimeout: 25 }
+  const timeouts = { callTimeout: 25 }
   const payload = JSON.stringify({ procedure: 'marco', args: ['polo', 42], timeouts })
   sinon.assert.calledWith(
     t.context.publishStub,


### PR DESCRIPTION
Closes #2 
Closes #3 
Closes #6

Changes the default timeouts for the reasons specified in the README. Adds exports so that `tsc --definitions` works for later publishing.